### PR TITLE
add csv name and version to must-gather

### DIFF
--- a/gather_gitops.sh
+++ b/gather_gitops.sh
@@ -272,6 +272,11 @@ function main() {
   echo " * Getting OpenShift Cluster Version..."
   run_and_log "oc version" "$GITOPS_DIR/oc-version.txt"
 
+  # requirement for custom must-gathers, see https://github.com/openshift/enhancements/blob/a5841f75dbc9afbab22e5baa8d2f1ff2f43e2df7/enhancements/oc/must-gather.md?plain=1#L88
+  echo " * Getting OpenShift GitOps Version..."
+  csv_name="$(oc -n openshift-gitops get csv -o name | grep 'openshift-gitops-operator')"
+  oc -n openshift-gitops get "${csv_name}" -o jsonpath='{.spec.displayName}{"\n"}{.spec.version}' > "$GITOPS_DIR/version.txt"
+
   echo " * Getting GitOps Operator Subscription..."
   run_and_log "oc get subs openshift-gitops-operator -n openshift-operators -o yaml" "$GITOPS_DIR/subscription.yaml"
   run_and_log "oc get subs openshift-gitops-operator -n openshift-operators -o json" "$GITOPS_DIR/subscription.json"


### PR DESCRIPTION
**What type of PR is this?**
 /kind enhancement

**What does this PR do / why we need it**:
This PR will add a new file under the `GITOPS_DIR` folder called `version.txt` that will output something similar to the following containing the product name and version. 
```
Red Hat OpenShift GitOps
1.7.2
```
This is a requirement of custom openshift must-gathers according to https://github.com/openshift/enhancements/blob/a5841f75dbc9afbab22e5baa8d2f1ff2f43e2df7/enhancements/oc/must-gather.md?plain=1#L88 

**How to test changes / Special notes to the reviewer**:
- checkout to this PR
- log into a cluster that has the gitops operator installed
- run `./gather_gitops.sh --base-collection-path .`