### PR TITLE
add openshift-ci buildroot Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,6 @@ push: image ## Push the image to the container registry
 
 clean: check-docker-podman ## Clean up the built image
 	${DOCKER_OR_PODMAN} rmi ${CONTAINER_IMAGE_LINK}
+
+test: test-unit
+	./test/suite.sh

--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -1,0 +1,20 @@
+# Dockerfile to bootstrap build and test in openshift-ci
+
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
+
+ARG KUBECTL_KUTTL_VERSION=0.12.1
+ARG OPERATOR_SDK_VERSION=1.22.2
+
+RUN yum -y install dnf httpd-tools podman docker
+
+# Install kubectl tool
+RUN curl -sSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+     chmod +x /usr/local/bin/kubectl
+
+# Install argocd cli tool
+RUN curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64 && \
+     chmod +x /usr/local/bin/argocd
+
+# Install operator-sdk
+RUN curl -L -o /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64 && \
+    chmod +x /usr/local/bin/operator-sdk


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
Part of adding ci integration with openshift-ci, this is based off of the [build-root Dockerfile of gitops-operator](https://github.com/redhat-developer/gitops-operator/blob/master/openshift-ci/build-root/Dockerfile). 

(May require later changes, this is only the initial step while trying to figure it out)