### PR TITLE
Add rollout namespaces to gather rollouts data

### DIFF
--- a/gather_gitops.sh
+++ b/gather_gitops.sh
@@ -148,8 +148,11 @@ get_namespaces() {
   local argocdInstances
   argocdInstances=$(oc get ArgoCD --all-namespaces -o jsonpath='{.items[*].metadata.namespace}')
 
+  local rolloutNamespaces
+  argocdInstances=$(oc get RolloutManager --all-namespaces -o jsonpath='{.items[*].metadata.namespace}')
+
   local total
-  total="${namespaces} ${argocdInstances}"
+  total="${namespaces} ${argocdInstances} ${rolloutNamespaces}"
   echo "${total}"
   
   NAMESPACES=$(echo "${total}" | tr ' ' '\n' | sort -u | tr '\n' ' ')

--- a/test/testdata/expected/test2.expected
+++ b/test/testdata/expected/test2.expected
@@ -229,6 +229,28 @@
         │   │   ├── argocd-server-xxxxxx-xxxxx.txt
         │   │   ├── argocd-server-xxxxxx-xxxxx.yaml
         │   │   └── replicaSets.txt
+        │   ├── rollouts
+        │   │   ├── cr
+        │   │   │   ├── rollouts-cr.json
+        │   │   │   └── rollouts-cr.yaml
+        │   │   ├── logs
+        │   │   │   └── rollout-logs.txt
+        │   │   ├── manager_cr
+        │   │   │   ├── rollouts-manager-cr.json
+        │   │   │   ├── rollouts-manager-cr.txt
+        │   │   │   └── rollouts-manager-cr.yaml
+        │   │   ├── rollout_deployment
+        │   │   │   ├── rollout-deployments.json
+        │   │   │   ├── rollout-deployments.txt
+        │   │   │   └── rollout-deployments.yaml
+        │   │   ├── rollout_replicaSet
+        │   │   │   ├── rollout-replicaSet.json
+        │   │   │   ├── rollout-replicaSet.txt
+        │   │   │   └── rollout-replicaSet.yaml
+        │   │   └── rollout_services
+        │   │       ├── rollout-service.json
+        │   │       ├── rollout-service.txt
+        │   │       └── rollout-service.yaml
         │   ├── routes
         │   │   ├── argocd-server.json
         │   │   ├── argocd-server.txt


### PR DESCRIPTION
**What type of PR is this?**
This issue https://issues.redhat.com/browse/GITOPS-3947 have been reopened because whenever a user creates an rollout manager the rollout data is not getting gathered, The fix for this is that we should get a namespace where rollout manager CR is created