### PR TITLE
ci: Enable konflux build

### DIFF
--- a/.konflux/Containerfile.plugin
+++ b/.konflux/Containerfile.plugin
@@ -1,0 +1,39 @@
+# Copyright 2023 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ------------------------------------------------------------------------
+FROM registry.redhat.io/openshift4/ose-must-gather:v4.13.0
+
+LABEL \
+    name="openshift-gitops-1/must-gather-rhel8" \
+    License="Apache 2.0" \
+    com.redhat.component="openshift-gitops-must-gather-container" \
+    com.redhat.delivery.appregistry="false" \ 
+    upstream-vcs-type="git" \
+    summary="OpenShift GitOps Must Gather" \
+    maintainer="William Tam <wtam@redhat.com>" \
+    io.k8s.display-name="Red Hat OpenShift GitOps Must Gather"\
+    io.openshift.tags="openshift,gitops-operator, must-gather" \
+    io.openshift.maintainer.product="Red Hat OpenShift GitOps" \
+    io.openshift.maintainer.component="William Tam <wtam@redhat.com>"  
+
+# Save original gather script
+RUN mv /usr/bin/gather /usr/bin/gather_original
+
+COPY gather_gitops.sh /usr/bin/gather
+
+# Make it executable
+RUN chmod +x /usr/bin/gather
+
+ENTRYPOINT /usr/bin/gather

--- a/.tekton/gitops-must-gather-pull-request.yaml
+++ b/.tekton/gitops-must-gather-pull-request.yaml
@@ -30,7 +30,9 @@ spec:
     value:
     - linux/x86_64
   - name: dockerfile
-    value: Dockerfile
+    value: .konflux/Containerfile.plugin
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -232,6 +234,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
+      - name: LABELS
+        value:
+        - upstream-source-url=$(tasks.clone-repository.results.url)
+        - upstream-source-ref=$(tasks.clone-repository.results.commit)
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/gitops-must-gather-push.yaml
+++ b/.tekton/gitops-must-gather-push.yaml
@@ -26,8 +26,13 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
-    value: Dockerfile
+    value: .konflux/Containerfile.plugin
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -229,6 +234,10 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
+      - name: LABELS
+        value:
+        - upstream-source-url=$(tasks.clone-repository.results.url)
+        - upstream-source-ref=$(tasks.clone-repository.results.commit)
       runAfter:
       - prefetch-dependencies
       taskRef:


### PR DESCRIPTION
**What type of PR is this?**
/kind ci


**What does this PR do / why we need it**:

Enables CI build on konflux. The PR job builds on amd only and the PUSH job builds on all supported arch i.e amd64, arm64, ppc64le & s390x.